### PR TITLE
Fix module version when built outside of autotools

### DIFF
--- a/build-aux/build.rs
+++ b/build-aux/build.rs
@@ -36,6 +36,9 @@ fn main() -> AnyhowResult<()> {
     if let Ok(val) = env::var("VERSION_FROM_AUTOTOOLS") {
         println!("cargo:rustc-env=VERGEN_GIT_DESCRIBE={val}");
         builder.add_instructions(&RustcBuilder::all_rustc()?)?;
+    } else if let Ok(val) = env::var("LUA_ROCKSPEC_VERSION") {
+        println!("cargo:rustc-env=VERGEN_GIT_DESCRIBE=v{val}");
+        builder.add_instructions(&RustcBuilder::all_rustc()?)?;
     } else {
         builder.add_instructions(&GixBuilder::all_git()?)?;
     };

--- a/decasify-dev-1.rockspec
+++ b/decasify-dev-1.rockspec
@@ -25,7 +25,7 @@ description = {
 
 dependencies = {
    "lua >= 5.1",
-   "luarocks-build-rust-mlua >= 0.2.2-1",
+   "luarocks-build-rust-mlua >= 0.2.3-1",
 }
 
 build = {

--- a/decasify.rockspec.in
+++ b/decasify.rockspec.in
@@ -23,7 +23,7 @@ description = {
 
 dependencies = {
    "lua >= 5.1",
-   "luarocks-build-rust-mlua >= 0.2.2-1",
+   "luarocks-build-rust-mlua >= 0.2.3-1",
 }
 
 build = {


### PR DESCRIPTION
Dependent on unreleased features in luarocks-build-rust-mlua, see https://github.com/mlua-rs/luarocks-build-rust-mlua/pull/16.