### PR TITLE
Refactor function names and add exported trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ lua52 = ["luamodule", "mlua/lua52"]
 lua51 = ["luamodule", "mlua/lua51"]
 luajit = ["luamodule", "mlua/luajit"]
 pythonmodule = ["dep:pyo3"]
+unstable-trait = []
 wasm = ["dep:wasm-bindgen"]
 
 [profile.release]
@@ -107,7 +108,7 @@ predicates = "3.1"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(build)'] }
 
 [package.metadata.docs.rs]
-features = ["luamodule", "luajit", "pythonmodule", "wasm"]
+features = ["luamodule", "luajit", "pythonmodule", "wasm", "unstable-trait"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.git-cliff.git]

--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,7 @@ docdir = $(datarootdir)/doc/$(TRANSFORMED_PACKAGE_NAME)
 licensedir = $(datarootdir)/licenses/$(TRANSFORMED_PACKAGE_NAME)
 
 bin_PROGRAMS = decasify
-decasify_SOURCES  = src/bin/decasify.rs src/content.rs src/cli.rs src/lib.rs src/types.rs
+decasify_SOURCES  = src/bin/decasify.rs src/content.rs src/cli.rs src/lib.rs src/types.rs str/traits.rs
 decasify_SOURCES += src/lua.rs src/python.rs src/wasm.rs
 decasify_SOURCES += src/en.rs src/tr.rs
 EXTRA_decasify_SOURCES = tests/cli.rs tests/lib.rs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![doc = include_str!("../README.md")]
 
 pub mod content;
+pub mod traits;
 pub mod types;
 
 pub use content::{Chunk, Segment};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ mod traits;
 mod types;
 
 pub use content::Chunk;
+#[cfg(feature = "unstable-trait")]
+pub use traits::Decasify;
 pub use types::{Case, Locale, StyleGuide};
 
 #[cfg(feature = "cli")]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2023 Caleb Maclennan <caleb@alerque.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+use crate::types::{Case, Locale, StyleGuide};
+
+pub trait Decasify {
+    fn to_case(
+        &self,
+        case: impl Into<Case>,
+        locale: impl Into<Locale>,
+        style: impl Into<StyleGuide>,
+    ) -> String;
+    fn to_titlecase(&self, locale: impl Into<Locale>, style: impl Into<StyleGuide>) -> String;
+    fn to_lowercase(&self, locale: impl Into<Locale>) -> String;
+    fn to_uppercase(&self, locale: impl Into<Locale>) -> String;
+    fn to_sentencecase(&self, locale: impl Into<Locale>) -> String;
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -15,3 +15,26 @@ pub trait Decasify {
     fn to_uppercase(&self, locale: impl Into<Locale>) -> String;
     fn to_sentencecase(&self, locale: impl Into<Locale>) -> String;
 }
+
+impl Decasify for str {
+    fn to_case(
+        &self,
+        case: impl Into<Case>,
+        locale: impl Into<Locale>,
+        style: impl Into<StyleGuide>,
+    ) -> String {
+        crate::case(self, case, locale, style)
+    }
+    fn to_titlecase(&self, locale: impl Into<Locale>, style: impl Into<StyleGuide>) -> String {
+        crate::titlecase(self, locale, style)
+    }
+    fn to_lowercase(&self, locale: impl Into<Locale>) -> String {
+        crate::lowercase(self, locale)
+    }
+    fn to_uppercase(&self, locale: impl Into<Locale>) -> String {
+        crate::uppercase(self, locale)
+    }
+    fn to_sentencecase(&self, locale: impl Into<Locale>) -> String {
+        crate::sentencecase(self, locale)
+    }
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -20,6 +20,81 @@ pub trait Decasify {
 
 #[cfg(feature = "unstable-trait")]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable-trait")))]
+impl Decasify for String {
+    fn to_case(
+        &self,
+        case: impl Into<Case>,
+        locale: impl Into<Locale>,
+        style: impl Into<StyleGuide>,
+    ) -> String {
+        crate::case(self, case, locale, style)
+    }
+    fn to_titlecase(&self, locale: impl Into<Locale>, style: impl Into<StyleGuide>) -> String {
+        crate::titlecase(self, locale, style)
+    }
+    fn to_lowercase(&self, locale: impl Into<Locale>) -> String {
+        crate::lowercase(self, locale)
+    }
+    fn to_uppercase(&self, locale: impl Into<Locale>) -> String {
+        crate::uppercase(self, locale)
+    }
+    fn to_sentencecase(&self, locale: impl Into<Locale>) -> String {
+        crate::sentencecase(self, locale)
+    }
+}
+
+#[cfg(feature = "unstable-trait")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable-trait")))]
+impl Decasify for &String {
+    fn to_case(
+        &self,
+        case: impl Into<Case>,
+        locale: impl Into<Locale>,
+        style: impl Into<StyleGuide>,
+    ) -> String {
+        crate::case(*self, case, locale, style)
+    }
+    fn to_titlecase(&self, locale: impl Into<Locale>, style: impl Into<StyleGuide>) -> String {
+        crate::titlecase(*self, locale, style)
+    }
+    fn to_lowercase(&self, locale: impl Into<Locale>) -> String {
+        crate::lowercase(*self, locale)
+    }
+    fn to_uppercase(&self, locale: impl Into<Locale>) -> String {
+        crate::uppercase(*self, locale)
+    }
+    fn to_sentencecase(&self, locale: impl Into<Locale>) -> String {
+        crate::sentencecase(*self, locale)
+    }
+}
+
+#[cfg(feature = "unstable-trait")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable-trait")))]
+impl Decasify for &str {
+    fn to_case(
+        &self,
+        case: impl Into<Case>,
+        locale: impl Into<Locale>,
+        style: impl Into<StyleGuide>,
+    ) -> String {
+        crate::case(*self, case, locale, style)
+    }
+    fn to_titlecase(&self, locale: impl Into<Locale>, style: impl Into<StyleGuide>) -> String {
+        crate::titlecase(*self, locale, style)
+    }
+    fn to_lowercase(&self, locale: impl Into<Locale>) -> String {
+        crate::lowercase(*self, locale)
+    }
+    fn to_uppercase(&self, locale: impl Into<Locale>) -> String {
+        crate::uppercase(*self, locale)
+    }
+    fn to_sentencecase(&self, locale: impl Into<Locale>) -> String {
+        crate::sentencecase(*self, locale)
+    }
+}
+
+#[cfg(feature = "unstable-trait")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable-trait")))]
 impl Decasify for str {
     fn to_case(
         &self,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,8 +1,10 @@
 // SPDX-FileCopyrightText: © 2023 Caleb Maclennan <caleb@alerque.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-use crate::types::{Case, Locale, StyleGuide};
+use crate::{Case, Locale, StyleGuide};
 
+#[allow(dead_code)]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable-trait")))]
 pub trait Decasify {
     fn to_case(
         &self,
@@ -16,6 +18,8 @@ pub trait Decasify {
     fn to_sentencecase(&self, locale: impl Into<Locale>) -> String;
 }
 
+#[cfg(feature = "unstable-trait")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable-trait")))]
 impl Decasify for str {
     fn to_case(
         &self,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: © 2023 Caleb Maclennan <caleb@alerque.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
+use decasify::traits::Decasify;
 use decasify::*;
 
 #[test]
@@ -19,6 +20,16 @@ fn cast_from_legacy_option() {
     assert_eq!(res, "Fist");
     let res = titlecase("FIST", "en", None);
     assert_eq!(res, "Fist");
+}
+
+#[test]
+fn trait_chery() {
+    let s = "WHY THE LONG FACE?";
+    assert_eq!(s.to_case("sentence", "en", None), "Why the long face?");
+    assert_eq!(
+        <str as Decasify>::to_lowercase(s, "en"),
+        "why the long face?"
+    );
 }
 
 macro_rules! case {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -31,6 +31,10 @@ fn trait_chery() {
         <str as Decasify>::to_lowercase(s, "en"),
         "why the long face?"
     );
+    assert_eq!(
+        s.to_owned().to_case("sentence", "en", None),
+        "Why the long face?"
+    );
 }
 
 macro_rules! case {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: © 2023 Caleb Maclennan <caleb@alerque.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-use decasify::traits::Decasify;
 use decasify::*;
 
 #[test]
@@ -22,8 +21,10 @@ fn cast_from_legacy_option() {
     assert_eq!(res, "Fist");
 }
 
+#[cfg(feature = "unstable-trait")]
 #[test]
 fn trait_chery() {
+    use decasify::Decasify;
     let s = "WHY THE LONG FACE?";
     assert_eq!(s.to_case("sentence", "en", None), "Why the long face?");
     assert_eq!(


### PR DESCRIPTION
- **refator!: Rename `to_*()` functions as just `*()`**
- **feat(crate): Specify Decasify trait**
