### PR TITLE
Preserve segmest styles in typesetter plugins

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -118,6 +118,8 @@ typst/decasify.wasm: typst/src/lib.rs
 
 SILEASSETS = sile/readme_1.svg sile/readme_2.svg
 
+SILE_EXPECTATIONS = tests/styled.txt
+
 .PHONY: sile-docs
 sile-docs: $(SILEASSETS)
 
@@ -127,16 +129,22 @@ sile-docs: $(SILEASSETS)
 %.pdf: %.sil
 	cp $< target/
 	cd target
-	$(SILE) $(<F) -o ../$@
+	$(SILE) -o ../$@ $(<F)
 
 %.svg: %.pdf
 	$(PDF2SVG) $< $@
 	$(SVGO) --multipass --precision 2 --pretty --indent 2 $@
 	$(SED) -i -e '/\/defs/a   <rect width="100%" height="100%" fill="white" />' $@
 
-check: busted pytest typst-test
+%.txt: %.sil sile-docs
+	cp $< target/
+	cd target
+	$(SILE) -b debug -o ../$@ $(<F)
+	$(SILE) $(<F)
 
-PHONY_DEVELOPER_TARGETS = rockspecs srcrocks rocks install-luarock busted pytest typst-test release-preview
+check: busted pytest sile-test typst-test
+
+PHONY_DEVELOPER_TARGETS = rockspecs srcrocks rocks install-luarock busted pytest sile-test typst-test release-preview
 .PHONY: $(PHONY_DEVELOPER_TARGETS)
 
 if DEVELOPER_MODE
@@ -176,6 +184,9 @@ pytest:
 	source .venv/bin/activate
 	$(MATURIN) develop
 	env PYTHONPATH=.venv/lib/python3.12/site-packages/decasify $(PYTEST)
+
+sile-test: $(SILE_EXPECTATIONS)
+	$(GIT) diff-files --quiet -- $^
 
 typst-test: $(TYPST_EXPECTATIONS)
 	$(GIT) diff-files --quiet -- $^

--- a/Makefile.am
+++ b/Makefile.am
@@ -142,6 +142,8 @@ sile-docs: $(SILEASSETS)
 	$(SILE) -b debug -o ../$@ $(<F)
 	$(SILE) $(<F)
 
+TESTS = tests/style.html
+
 check: busted pytest sile-test typst-test
 
 PHONY_DEVELOPER_TARGETS = rockspecs srcrocks rocks install-luarock busted pytest sile-test typst-test release-preview

--- a/Makefile.am
+++ b/Makefile.am
@@ -85,6 +85,8 @@ sile/readme_%.sil: sile/README.md $(CODEBLOCK_FILTER)
 
 TYPSTASSETS = typst/decasify.wasm typst/readme_1.svg typst/readme_2.svg typst/LICENSE
 
+TYPST_EXPECTATIONS = tests/styled.html
+
 .PHONY: typst-universe
 typst-universe: $(TYPSTASSETS)
 
@@ -111,6 +113,9 @@ typst/decasify.wasm: typst/src/lib.rs
 	$(TYPST) compile -f svg $< $@
 	$(SVGO) --multipass --precision 2 --pretty --indent 2 $@
 
+%.html: %.typ typst-universe
+	$(TYPST) compile --root $(top_srcdir) --features html --format html $<
+
 SILEASSETS = sile/readme_1.svg sile/readme_2.svg
 
 .PHONY: sile-docs
@@ -129,9 +134,9 @@ sile-docs: $(SILEASSETS)
 	$(SVGO) --multipass --precision 2 --pretty --indent 2 $@
 	$(SED) -i -e '/\/defs/a   <rect width="100%" height="100%" fill="white" />' $@
 
-check: busted pytest
+check: busted pytest typst-test
 
-PHONY_DEVELOPER_TARGETS = rockspecs srcrocks rocks install-luarock busted pytest release-preview
+PHONY_DEVELOPER_TARGETS = rockspecs srcrocks rocks install-luarock busted pytest typst-test release-preview
 .PHONY: $(PHONY_DEVELOPER_TARGETS)
 
 if DEVELOPER_MODE
@@ -171,6 +176,9 @@ pytest:
 	source .venv/bin/activate
 	$(MATURIN) develop
 	env PYTHONPATH=.venv/lib/python3.12/site-packages/decasify $(PYTEST)
+
+typst-test: $(TYPST_EXPECTATIONS)
+	$(GIT) diff-files --quiet -- $^
 
 define rockpec_template =
 	$(SED) -e "s/@""PACKAGE_NAME""@/$(PACKAGE_NAME)/g" \

--- a/tests/styled.html
+++ b/tests/styled.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    <table>
+      <tr>
+        <td>Source</td>
+        <td>this sample <strong>has bold</strong> and <em>italic underlined</em> bits.</td>
+      </tr>
+    </table>
+    <h2>Sentencecase</h2>
+    <table>
+      <tr>
+        <td>Actual</td>
+        <td>This sample <strong>has bold</strong> and <em>italic underlined</em> bits.</td>
+      </tr>
+      <tr>
+        <td>Expected</td>
+        <td>This sample <strong>has bold</strong> and <em>italic underlined</em> bits.</td>
+      </tr>
+    </table>
+    <h2>Titlecase</h2>
+    <table>
+      <tr>
+        <td>Actual</td>
+        <td>This Sample <strong>Has Bold</strong> and <em>Italic Underlined</em> Bits.</td>
+      </tr>
+      <tr>
+        <td>Expected</td>
+        <td>This Sample <strong>Has Bold</strong> and <em>Italic Underlined</em> Bits.</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/tests/styled.sil
+++ b/tests/styled.sil
@@ -1,0 +1,18 @@
+\begin{document}
+\nofolios
+\neverindent
+\language[main=en]
+\use[module=packages.rules]
+\use[module=packages.decasify]
+\define[command=sample]{this sample \strong{has bold} and \em{italic \underline{underlined}} bits.}
+\define[command=group]{\bigskip\font[size=16pt,weight=800]{\process}\par}
+
+\sample
+
+\group{Sentencecase}
+\decasify[case=sentence]{this sample \strong{has bold} and \em{italic \underline{underlined}} bits.}
+
+\group{Titlecase}
+\decasify[case=title]{this sample \strong{has bold} and \em{italic \underline{underlined}} bits.}
+
+\end{document}

--- a/tests/styled.typ
+++ b/tests/styled.typ
@@ -1,0 +1,23 @@
+#import "../typst/decasify.typ": sentencecase, titlecase
+
+#set text(lang: "en")
+
+#let sample = [this sample *has bold* and _italic #underline[underlined]_ bits.]
+
+#table(columns: (2cm, 9cm))[Source][#sample]
+
+= Sentencecase
+
+#table(columns: (2cm, 9cm))[Actual][
+  #sentencecase[#sample]
+][Expected][
+  This sample *has bold* and _italic #underline[underlined]_ bits.
+]
+
+= Titlecase
+
+#table(columns: (2cm, 9cm))[Actual][
+  #titlecase[#sample]
+][Expected][
+  This Sample *Has Bold* and _Italic #underline[Underlined]_ Bits.
+]


### PR DESCRIPTION
Both the Typst (#38) and SILE (#41) packages are passed and hence process each segment of text in separate chunks. In both cases this means a change in style that creates segmented text gets cased per-segment, which is more often than not an unexpected outcome. This PR can be split if one or the other typesetter package is fixed first. Conceptually they are similar and I started working on tests for both, but they may or may not both have solutions.